### PR TITLE
Add localization messages and usage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,9 @@ APP_DEBUG=true
 #APP_URL={app_url}
 
 APP_TIMEZONE=UTC
+# Primary application language
 APP_LOCALE=en
+# Fallback language if translation is missing
 APP_FALLBACK_LOCALE=en
 APP_FAKER_LOCALE=en_US
 APP_MAINTENANCE_DRIVER=file

--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ For Laravel Sail, install:
 If not creating inside of vagrant, you may need to create your .env file by copying .env.example to .env and providing
 the database configuration settings (host, name, username and password).
 
+The `.env` file also includes localization options:
+`APP_LOCALE` sets the primary application language and `APP_FALLBACK_LOCALE`
+defines the fallback language when a translation is missing. By default both are
+set to `en`, but you may change them to `es` or `pt` as needed.
+
 Following commands must be executed **inside** your vagrant box.
 * `cd code`
 * `php artisan migrate:fresh --seed`
@@ -85,6 +90,9 @@ TWILIO_SID={twilio_sid}
 TWILIO_TOKEN={twilio_token}
 
 GOOGLE_CALENDAR_ID={google_calendar_id}
+# Optional localization settings
+APP_LOCALE=en
+APP_FALLBACK_LOCALE=en
 ```
 For **Google People API** replace `{google_client_id}` with your `client ID` and `{google_client_secret}` with your `client secret`.
 

--- a/lang/en/messages.php
+++ b/lang/en/messages.php
@@ -1,0 +1,13 @@
+<?php
+return [
+    'welcome' => 'Welcome to Polanco!',
+    'login' => 'Login',
+    'register' => 'Register',
+    'logout' => 'Logout',
+    'email' => 'E-Mail Address',
+    'password' => 'Password',
+    'remember_me' => 'Remember Me',
+    'forgot_password' => 'Forgot Your Password?',
+    'name' => 'Name',
+    'confirm_password' => 'Confirm Password',
+];

--- a/lang/es/messages.php
+++ b/lang/es/messages.php
@@ -1,0 +1,13 @@
+<?php
+return [
+    'welcome' => '¡Bienvenido a Polanco!',
+    'login' => 'Iniciar sesión',
+    'register' => 'Registrarse',
+    'logout' => 'Cerrar sesión',
+    'email' => 'Correo electrónico',
+    'password' => 'Contraseña',
+    'remember_me' => 'Recordarme',
+    'forgot_password' => '¿Olvidó su contraseña?',
+    'name' => 'Nombre',
+    'confirm_password' => 'Confirmar contraseña',
+];

--- a/lang/pt/messages.php
+++ b/lang/pt/messages.php
@@ -1,0 +1,13 @@
+<?php
+return [
+    'welcome' => 'Bem-vindo ao Polanco!',
+    'login' => 'Entrar',
+    'register' => 'Registrar',
+    'logout' => 'Sair',
+    'email' => 'Endereço de e-mail',
+    'password' => 'Senha',
+    'remember_me' => 'Lembrar-me',
+    'forgot_password' => 'Esqueceu sua senha?',
+    'name' => 'Nome',
+    'confirm_password' => 'Confirmar senha',
+];

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -5,13 +5,13 @@
     <div class="row">
         <div class="col-md-8 col-md-offset-2">
             <div class="panel panel-default">
-                <div class="panel-heading">Login</div>
+                <div class="panel-heading">{{ __('messages.login') }}</div>
                 <div class="panel-body">
                     <form class="form-horizontal" role="form" method="POST" action="{{ route('login') }}">
                         @csrf
 
                         <div class="form-group{{ $errors->has('email') ? ' has-error' : '' }}">
-                            <label for="email" class="col-md-4 control-label">E-Mail Address</label>
+                            <label for="email" class="col-md-4 control-label">{{ __('messages.email') }}</label>
 
                             <div class="col-md-6">
                                 <input id="email" type="email" class="form-control" name="email" value="{{ old('email') }}" required autofocus>
@@ -25,7 +25,7 @@
                         </div>
 
                         <div class="form-group{{ $errors->has('password') ? ' has-error' : '' }}">
-                            <label for="password" class="col-md-4 control-label">Password</label>
+                            <label for="password" class="col-md-4 control-label">{{ __('messages.password') }}</label>
 
                             <div class="col-md-6">
                                 <input id="password" type="password" class="form-control" name="password" required>
@@ -42,7 +42,7 @@
                             <div class="col-md-6 col-md-offset-4">
                                 <div class="checkbox">
                                     <label>
-                                        <input type="checkbox" name="remember" {{ old('remember') ? 'checked' : '' }}> Remember Me
+                                        <input type="checkbox" name="remember" {{ old('remember') ? 'checked' : '' }}> {{ __('messages.remember_me') }}
                                     </label>
                                 </div>
                             </div>
@@ -51,11 +51,11 @@
                         <div class="form-group">
                             <div class="col-md-8 col-md-offset-4">
                                 <button type="submit" class="btn btn-primary">
-                                    Login
+                                    {{ __('messages.login') }}
                                 </button>
 
                                 <a class="btn btn-link" href="{{ route('password.request') }}">
-                                    Forgot Your Password?
+                                    {{ __('messages.forgot_password') }}
                                 </a>
                             </div>
                         </div>

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -5,13 +5,13 @@
     <div class="row">
         <div class="col-md-8 col-md-offset-2">
             <div class="panel panel-default">
-                <div class="panel-heading">Register</div>
+                <div class="panel-heading">{{ __('messages.register') }}</div>
                 <div class="panel-body">
                     <form class="form-horizontal" role="form" method="POST" action="{{ route('register') }}">
                         @csrf
 
                         <div class="form-group{{ $errors->has('name') ? ' has-error' : '' }}">
-                            <label for="name" class="col-md-4 control-label">Name</label>
+                            <label for="name" class="col-md-4 control-label">{{ __('messages.name') }}</label>
 
                             <div class="col-md-6">
                                 <input id="name" type="text" class="form-control" name="name" value="{{ old('name') }}" required autofocus>
@@ -25,7 +25,7 @@
                         </div>
 
                         <div class="form-group{{ $errors->has('email') ? ' has-error' : '' }}">
-                            <label for="email" class="col-md-4 control-label">E-Mail Address</label>
+                            <label for="email" class="col-md-4 control-label">{{ __('messages.email') }}</label>
 
                             <div class="col-md-6">
                                 <input id="email" type="email" class="form-control" name="email" value="{{ old('email') }}" required>
@@ -39,7 +39,7 @@
                         </div>
 
                         <div class="form-group{{ $errors->has('password') ? ' has-error' : '' }}">
-                            <label for="password" class="col-md-4 control-label">Password</label>
+                            <label for="password" class="col-md-4 control-label">{{ __('messages.password') }}</label>
 
                             <div class="col-md-6">
                                 <input id="password" type="password" class="form-control" name="password" required>
@@ -53,7 +53,7 @@
                         </div>
 
                         <div class="form-group">
-                            <label for="password-confirm" class="col-md-4 control-label">Confirm Password</label>
+                            <label for="password-confirm" class="col-md-4 control-label">{{ __('messages.confirm_password') }}</label>
 
                             <div class="col-md-6">
                                 <input id="password-confirm" type="password" class="form-control" name="password_confirmation" required>
@@ -63,7 +63,7 @@
                         <div class="form-group">
                             <div class="col-md-6 col-md-offset-4">
                                 <button type="submit" class="btn btn-primary">
-                                    Register
+                                    {{ __('messages.register') }}
                                 </button>
                             </div>
                         </div>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -50,8 +50,8 @@
                     <ul class="nav navbar-nav navbar-right">
                         <!-- Authentication Links -->
                         @if (Auth::guest())
-                            <li><a href="{{ route('login') }}">Login</a></li>
-                            <li><a href="{{ route('register') }}">Register</a></li>
+                            <li><a href="{{ route('login') }}">{{ __('messages.login') }}</a></li>
+                            <li><a href="{{ route('register') }}">{{ __('messages.register') }}</a></li>
                         @else
                             <li class="dropdown">
                                 <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">
@@ -63,7 +63,7 @@
                                         <a href="{{ route('logout') }}"
                                             onclick="event.preventDefault();
                                                      document.getElementById('logout-form').submit();">
-                                            Logout
+                                            {{ __('messages.logout') }}
                                         </a>
 
                                         <form id="logout-form" action="{{ route('logout') }}" method="POST" style="display: none;">

--- a/resources/views/template.blade.php
+++ b/resources/views/template.blade.php
@@ -173,15 +173,15 @@
 						<img src="{{ Auth::user()->avatar }}" alt="{{ Auth::user()->name }}" title="{{ Auth::user()->name }}" class="rounded-circle avatar">
 					</div>
 					<div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuButton">
-						<a class="dropdown-item" href={{ route('logout') }}>Logout</a>
+                                                <a class="dropdown-item" href={{ route('logout') }}>{{ __('messages.logout') }}</a>
 					</div>
 				</div>
 
 
 				@else
-				<a href={{ route('login') }}>
-					Login
-				</a>
+                                <a href={{ route('login') }}>
+                                        {{ __('messages.login') }}
+                                </a>
 				@endauth
 			</div>
 		</nav>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -2,7 +2,7 @@
 @section('content')
 <div class="row">
 	<div class="col-lg-12 text-center">
-		<h1>Welcome to Polanco, the Montserrat Jesuit Retreat House Database!</h1>
+                <h1>{{ __('messages.welcome') }}</h1>
 		<p><a href="https://en.wikipedia.org/wiki/Juan_Alfonso_de_Polanco" target="_blank">Polanco</a> is your friendly assistant for managing information and making all of our lives a little easier.</p>
 		<p><a href="https://bible.usccb.org/bible/readings/" target="_blank">Today's Readings</a></p>
 <!--		<p>{!! $quote !!}</p>  -->


### PR DESCRIPTION
## Summary
- add sample translation files for English, Spanish and Portuguese
- use translation helpers in the auth views and layouts
- tweak welcome page string
- document `APP_LOCALE` and `APP_FALLBACK_LOCALE`
- comment localization variables in `.env.example`

## Testing
- `composer install` *(fails: command not found)*
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68486783cb908324b8bb9eaf903b55cf